### PR TITLE
Add a GitHub Actions workflow to automatically build docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'app version'
+        type: string
+        required: true
+env:
+  DOCKERFILE_PATH: Dockerfile  # Make Dockerfile path configurable
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6.17.0
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            r3_version=${{inputs.version}}
+            r3_db_host=r3-db
+            r3_db_name=app
+            r3_db_user=app
+            r3_db_pass=app
+            r3_os_arch=arm64
+            im_policy=/etc/ImageMagick-6/policy.xml
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,11 +2,11 @@ name: Docker Image CI
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'app version'
-        type: string
-        required: true
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 3 * * 1"
 env:
   DOCKERFILE_PATH: Dockerfile  # Make Dockerfile path configurable
   # Use docker.io for Docker Hub if empty
@@ -36,7 +36,10 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Get latest version code
+        id: generate_versionno
+        run: |-
+          curl -fsSL "https://api.github.com/repos/r3-team/r3/tags" | jq -r '.[0].name | sub("v";"ver=";"i")' 
 
       - name: Build and Push ARM64 Docker Image
         uses: docker/build-push-action@v6.17.0
@@ -44,7 +47,7 @@ jobs:
           context: .
           platforms: linux/arm64
           build-args: |
-            r3_version=${{inputs.version}}
+            r3_version=${{ steps.generate_versionno.outputs.ver }}
             r3_db_host=r3-db
             r3_db_name=app
             r3_db_user=app
@@ -53,7 +56,7 @@ jobs:
             im_policy=/etc/ImageMagick-6/policy.xml
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.generate_versionno.outputs.ver }}-arm64
 
 
       - name: Build and Push AMD64 Docker Image
@@ -62,7 +65,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: |
-            r3_version=${{inputs.version}}
+            r3_version=${{ steps.generate_versionno.outputs.ver }}
             r3_db_host=r3-db
             r3_db_name=app
             r3_db_user=app
@@ -71,4 +74,4 @@ jobs:
             im_policy=/etc/ImageMagick-6/policy.xml
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}-amd64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.generate_versionno.outputs.ver }}-amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
 
-      - name: Build and Push Docker Image
+      - name: Build and Push ARM64 Docker Image
         uses: docker/build-push-action@v6.17.0
         with:
           context: .
@@ -53,4 +53,22 @@ jobs:
             im_policy=/etc/ImageMagick-6/policy.xml
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}-arm64
+
+
+      - name: Build and Push AMD64 Docker Image
+        uses: docker/build-push-action@v6.17.0
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            r3_version=${{inputs.version}}
+            r3_db_host=r3-db
+            r3_db_name=app
+            r3_db_user=app
+            r3_db_pass=app
+            r3_os_arch=x64
+            im_policy=/etc/ImageMagick-6/policy.xml
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{inputs.version}}-amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Get latest version code
         id: generate_versionno
         run: |-
-          curl -fsSL "https://api.github.com/repos/r3-team/r3/tags" | jq -r '.[0].name | sub("v";"ver=";"i")' 
+          curl -fsSL "https://api.github.com/repos/r3-team/r3/tags" | jq -r '.[0].name | sub("v";"ver=";"i")' >> $GITHUB_OUTPUT
 
       - name: Build and Push ARM64 Docker Image
         uses: docker/build-push-action@v6.17.0


### PR DESCRIPTION
This workflow (based on the "Publish Docker Container" template) automatically builds the latest version of REI3 and pushes it to GitHub's container registry.

It is not perfect (there can be multiple builds of the same version) but it gets the job done in a simple way.

I've tested it on my r3_docker fork and it works well.

Also, GitHub actions disables Actions if the repository does not have activity for 60 days. ( [possible workaround](https://github.com/orgs/community/discussions/26323#discussioncomment-3251443) )

Looking forward to see this added, so that i don't have to compile REI3 on my slow Raspberry Pi.